### PR TITLE
Implement battery voltage sensor

### DIFF
--- a/raspiaudio-muse-luxe.yaml
+++ b/raspiaudio-muse-luxe.yaml
@@ -53,6 +53,22 @@ media_player:
 
 es8388:
 
+sensor:
+ - platform: adc
+   pin: GPIO33
+   name: ${name} Battery
+   icon: "mdi:battery-outline"
+   update_interval: 60s
+   accuracy_decimals: 2
+   attenuation: 11db
+   raw: true
+   filters:
+    - multiply: 0.00173913 # 2300 -> 4, for attenuation 11db, based on Olivier's code
+    - sliding_window_moving_average:
+         window_size: 10
+         send_every: 2
+    - delta: 0.01
+
 binary_sensor:
   - platform: gpio
     pin:


### PR DESCRIPTION
As I don't have access to the board (yet - anyone knows how to open the case without breaking anything?) I based the multiplier on values from Olivier Ros' code:
  4V -> 2300
  3.6V -> 2000
(with attenuation: 11db)
As those values are not quite consistent the scaling - and thus the readout - may be off a bit.

For now I have not added a voltage feedback through the LED as Olivier has, but that would be a straightforward addition. 